### PR TITLE
Save temp mmemap with four string digits

### DIFF
--- a/use_cases/DeZeeuw/abadura_demo.py
+++ b/use_cases/DeZeeuw/abadura_demo.py
@@ -171,7 +171,7 @@ else:
     dview = c[:len(c)]
 #%% set parameters and create template by rigid motion correction
 t1 = time.time()
-fname = '20_12__006.tif'
+fname = '20_12__002_cr.tif'
 max_shifts = (12,12)
 splits = 28 # for parallelization split the movies in  num_sqplits chuncks across time
 m = cm.load(fname,subindices=slice(None,None,None))
@@ -181,7 +181,6 @@ m.play(gain = 1,magnification=1,fr =60)
 template = cm.motion_correction.bin_median( m[100:500].copy().motion_correct(max_shifts[0],max_shifts[1],template=None)[0])
 pl.imshow(template)
 #%%
-
 new_templ = template
 add_to_movie=-np.min(template)
 save_movie = False
@@ -219,7 +218,7 @@ mr = cm.load(fname_tot)
 fnames = [fname_tot]
 #%%
 idx_x=slice(12,500,None)
-idx_y=slice((796-512)/2,-(796-512)/2,None)
+idx_y=slice(12,500,None)
 idx_xy=(idx_x,idx_y)
 add_to_movie=-np.nanmin(mr) # the movie must be positive!!!
 downsample_factor=.2 # use .2 or .1 if file is large and you want a quick answer


### PR DESCRIPTION
I've noted a small bug in the function save_memmap_each (line 109 of file mmaping.py). I would suggest instead of: base_name+str(idx), to write instead: base_name+'{:04d}'.format(idx) . The reason is that after this function is called in the main code, you do: name_new.sort(). The problem is if you have the data contained in more than 10 tiff files, then you'll have a mismatch because the order will be the following: _1,_10,_11,.._19,_2,_20,_21,...,_3.. and so on.