### PR TITLE
possible fence post error in extract_patch_coordinates

### DIFF
--- a/caiman/cluster.py
+++ b/caiman/cluster.py
@@ -55,12 +55,12 @@ def extract_patch_coordinates(d1,d2,rf=(7,7),stride = (2,2)):
     iter_1 = list(range(rf2,d2-rf2,2*rf2-stride2))+[d2-rf2]
     coords_2d = np.empty([len(iter_0),len(iter_1),2],dtype=np.object)   
     for count_0,xx in enumerate(iter_0):
-        coords_x=np.array(list(range(xx - rf1, xx + rf1 + 1))) 
+        coords_x=np.array(list(range(xx - rf1, xx + rf1))) 
         coords_x = coords_x[(coords_x >= 0) & (coords_x < d1)]
         for count_1,yy in enumerate(iter_1):
 
 
-            coords_y = np.array(list(range(yy - rf2, yy + rf2 + 1)))  
+            coords_y = np.array(list(range(yy - rf2, yy + rf2)))  
 #            print([xx - rf1, xx + rf1 + 1,yy - rf2, yy + rf2 + 1])
             coords_y = coords_y[(coords_y >= 0) & (coords_y < d2)]
 


### PR DESCRIPTION
Hello,

First off thanks for the toolbox, we've been making good use of it at our lab.

I think you might have a small fence post error in extract_patch_coordinates caused by the difference in array indexing between between Matlab and Numpy (as in 1 versus 0 based array indexes).

To be specific, when I execute the following:

idx_flat, idx_2d = extract_patch_coordinates(d1=256, d2=256, rf=(7,7), stride = (2,2))

I expect idx_2d[0,0,0] for example, to be of shape (14, 14) and contain row indices from 0 to 13. Instead it's of shape (15,15) and contains indices 0 to 14.

Assuming that's right, this can be corrected by removing the +1 from the range() parameters when calculating coords_x / coords_y