### PR TITLE
Assert that shape argument to np.ones is an int

### DIFF
--- a/caiman/components_evaluation.py
+++ b/caiman/components_evaluation.py
@@ -144,7 +144,7 @@ def find_activity_intervals(C,Npeaks = 5, tB=-5, tA = 25, thres = 0.3):
     LOC = []
     for i in range(K):
         if len(L[i])>0:
-            interval = np.kron(L[i],np.ones(tA-tB,dtype=int)) + np.kron(np.ones(len(L[i]),dtype=int),np.arange(tB,tA))                        
+            interval = np.kron(L[i],np.ones(int(np.round(tA-tB)),dtype=int)) + np.kron(np.ones(len(L[i]),dtype=int),np.arange(tB,tA))                        
             interval[interval<0] = 0
             interval[interval>T-1] = T-1
             LOC.append(np.array(list(set(interval))))        


### PR DESCRIPTION
Newer versions of numpy are getting increasingly pedantic about the types of indices, to the point where they will throw a TypeError when a float is used as an index.