### PR TITLE
Fix bugs with newer version of bokeh & Python 3's urllib

### DIFF
--- a/caiman/utils/utils.py
+++ b/caiman/utils/utils.py
@@ -9,15 +9,18 @@ from __future__ import print_function
 #%%
 import numpy as np
 import os
-import urllib2
+try:
+    import urllib2.urlopen as urlopen
+except:
+    import urllib.request.urlopen as urlopen
 import requests
 #%%
 def download_demo():
     if os.path.exists('./example_movies'):
         if not(os.path.exists('./example_movies/demoSue2x.tif')):        
             url = 'https://www.dropbox.com/s/09z974vkeg3t5gn/Sue_2x_3000_40_-46.tif?dl=1'
-            print("downloading demo Sue2x with urllib2")
-            f = urllib2.urlopen(url)
+            print("downloading demo Sue2x with urllib")
+            f = urlopen(url)
             data = f.read()
             with open("./example_movies/demoSue2x.tif", "wb") as code:
                 code.write(data)

--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -25,7 +25,12 @@ import matplotlib as mpl
 try:
     import bokeh
     import bokeh.plotting as bpl
-    from bokeh.io import vform, hplot
+    try:
+        from bokeh.io import vform, hplot
+    except:
+        # newer version of bokeh does not use vform & hplot, instead uses column & row
+        from bokeh.layouts import column as vform
+        from bokeh.layouts import row as hplot
     from bokeh.models import CustomJS, ColumnDataSource, Range1d
 except:
     print("Bokeh could not be loaded. Either it is not installed or you are not running within a notebook")


### PR DESCRIPTION
This commit fixes two bugs:

1. Python 3 replaces `urllib2` with `urrllib.request` and `urllib.error`. `urllib.request.urlopen()` in Python 3 is equivalent to `urllib2.urlopen()` in Python 2.

2. Newer versions of the bokeh package don't use `vform()` & `hplot()`, instead they use `row()` and `column()`, which seem to work equivalently.