### PR TITLE
Small fix to deal with alpha_snmf=None

### DIFF
--- a/caiman/cluster.py
+++ b/caiman/cluster.py
@@ -413,12 +413,7 @@ def setup_cluster(backend = 'local',n_processes = None,single_thread = False):
             n_processes = np.int(os.environ.get('SLURM_NPROCS'))
         else:
             # roughly number of cores on your machine minus 1
-
             n_processes = np.maximum(np.int(psutil.cpu_count()), 1)
-
-    print(('using ' + str(n_processes) + ' processes'))
-
-
 
     if single_thread:
         dview = None

--- a/caiman/cluster.py
+++ b/caiman/cluster.py
@@ -25,7 +25,7 @@ from .mmapping import load_memmap
 #%%
 def get_patches_from_image(img,shapes,overlaps):
     d1,d2 = np.shape(img)
-    rf =  np.divide(shapes,2)    
+    rf =  np.divide(shapes,2)
     _,coords_2d  = extract_patch_coordinates(d1,d2,rf=rf,stride = overlaps)
     imgs = np.empty(coords_2d.shape[:2],dtype = np.object)
 
@@ -39,11 +39,11 @@ def extract_patch_coordinates_old(d1,d2,rf=(7,7),stride = (2,2)):
     """
     Function that partition the FOV in patches and return the indexed in 2D and 1D (flatten, order='F') formats
     Parameters
-    ----------    
+    ----------
     d1,d2: int
         dimensions of the original matrix that will be  divided in patches
     rf: int
-        radius of receptive field, corresponds to half the size of the square patch        
+        radius of receptive field, corresponds to half the size of the square patch
     stride: int
         degree of overlap of the patches
     """
@@ -53,14 +53,14 @@ def extract_patch_coordinates_old(d1,d2,rf=(7,7),stride = (2,2)):
     stride1,stride2 = stride
     iter_0 = list(range(rf1,d1-rf1,2*rf1-stride1))+[d1-rf1]
     iter_1 = list(range(rf2,d2-rf2,2*rf2-stride2))+[d2-rf2]
-    coords_2d = np.empty([len(iter_0),len(iter_1),2],dtype=np.object)   
+    coords_2d = np.empty([len(iter_0),len(iter_1),2],dtype=np.object)
     for count_0,xx in enumerate(iter_0):
-        coords_x=np.array(list(range(xx - rf1, xx + rf1 + 1))) 
+        coords_x=np.array(list(range(xx - rf1, xx + rf1 + 1)))
         coords_x = coords_x[(coords_x >= 0) & (coords_x < d1)]
         for count_1,yy in enumerate(iter_1):
 
 
-            coords_y = np.array(list(range(yy - rf2, yy + rf2 + 1)))  
+            coords_y = np.array(list(range(yy - rf2, yy + rf2 + 1)))
 #            print([xx - rf1, xx + rf1 + 1,yy - rf2, yy + rf2 + 1])
             coords_y = coords_y[(coords_y >= 0) & (coords_y < d2)]
 
@@ -126,20 +126,20 @@ def extract_rois_patch(file_name,d1,d2,rf=5,stride = 5):
     n_components=2
     tol=1e-6
     max_iter=5000
-    args_in=[]    
-    for id_f,id_2d in zip(idx_flat[:],idx_2d[:]):        
+    args_in=[]
+    for id_f,id_2d in zip(idx_flat[:],idx_2d[:]):
         args_in.append((file_name, id_f,id_2d, perctl,n_components,tol,max_iter))
     st=time.time()
     print((len(idx_flat)))
     try:
         if 1:
-            c = Client()   
+            c = Client()
             dview=c[:]
-            file_res = dview.map_sync(nmf_patches, args_in)                         
+            file_res = dview.map_sync(nmf_patches, args_in)
         else:
-            file_res = list(map(nmf_patches, args_in))                         
+            file_res = list(map(nmf_patches, args_in))
     finally:
-        dview.results.clear()   
+        dview.results.clear()
         c.purge_results('all')
         c.purge_everything()
         c.close()
@@ -152,8 +152,8 @@ def extract_rois_patch(file_name,d1,d2,rf=5,stride = 5):
     C2=[]
     for count,f in enumerate(file_res):
         idx_,flt,ca,d=f
-        A1[idx_,count]=flt[:,0][:,np.newaxis]        
-        A2[idx_,count]=flt[:,1][:,np.newaxis]        
+        A1[idx_,count]=flt[:,0][:,np.newaxis]
+        A2[idx_,count]=flt[:,1][:,np.newaxis]
         C1.append(ca[0,:])
         C2.append(ca[1,:])
 #        pl.imshow(np.reshape(flt[:,0],d,order='F'),vmax=10)
@@ -166,16 +166,16 @@ def apply_to_patch(mmap_file, shape, dview, rf , stride , function, *args, **kwa
     '''
     apply function to patches in parallel or not
 
-    Parameters    
-    ----------        
+    Parameters
+    ----------
     file_name: string
-        full path to an npy file (2D, pixels x time) containing the movie        
+        full path to an npy file (2D, pixels x time) containing the movie
 
     shape: tuple of three elements
-        dimensions of the original movie across y, x, and time 
+        dimensions of the original movie across y, x, and time
 
 
-    rf: int 
+    rf: int
         half-size of the square patch in pixel
 
     stride: int
@@ -189,7 +189,7 @@ def apply_to_patch(mmap_file, shape, dview, rf , stride , function, *args, **kwa
     Returns
     -------
     results
-    '''    
+    '''
 
     (T,d1,d2)=shape
     d=d1*d2
@@ -200,7 +200,7 @@ def apply_to_patch(mmap_file, shape, dview, rf , stride , function, *args, **kwa
         rf1=rf
         rf2=rf
 
-    if not np.isscalar(stride):    
+    if not np.isscalar(stride):
         stride1,stride2=stride
     else:
         stride1=stride
@@ -214,13 +214,13 @@ def apply_to_patch(mmap_file, shape, dview, rf , stride , function, *args, **kwa
     if d1 <= rf1*2:
         shape_grid = (1,shape_grid[1])
     if d2 <= rf2*2:
-        shape_grid = (shape_grid[0],1)    
+        shape_grid = (shape_grid[0],1)
 
     print(shape_grid)
 
-    args_in=[]    
+    args_in=[]
 
-    for id_f,id_2d in zip(idx_flat[:],idx_2d[:]):        
+    for id_f,id_2d in zip(idx_flat[:],idx_2d[:]):
 
         args_in.append((mmap_file.filename, id_f,id_2d, function, args, kwargs))
 
@@ -233,12 +233,12 @@ def apply_to_patch(mmap_file, shape, dview, rf , stride , function, *args, **kwa
 
         try:
 
-            file_res = dview.map_sync(function_place_holder, args_in)  
+            file_res = dview.map_sync(function_place_holder, args_in)
 
-            dview.results.clear()   
+            dview.results.clear()
 
         except:
-            print('Something went wrong')  
+            print('Something went wrong')
             raise
         finally:
             print('You may think that it went well but reality is harsh')
@@ -246,18 +246,18 @@ def apply_to_patch(mmap_file, shape, dview, rf , stride , function, *args, **kwa
 
     else:
 
-        file_res = list(map(function_place_holder, args_in))      
+        file_res = list(map(function_place_holder, args_in))
 
     return file_res, idx_flat, shape_grid
 #%%
 def function_place_holder(args_in):
 
     file_name, idx_,shapes,function, args, kwargs = args_in
-    Yr, _, _ = load_memmap(file_name)   
+    Yr, _, _ = load_memmap(file_name)
     Yr = Yr[idx_,:]
     Yr.filename=file_name
-    d,T=Yr.shape      
-    Y=np.reshape(Yr,(shapes[1],shapes[0],T),order='F').transpose([2,0,1])           
+    d,T=Yr.shape
+    Y=np.reshape(Yr,(shapes[1],shapes[0],T),order='F').transpose([2,0,1])
     [T,d1,d2]=Y.shape
 
     res_fun = function(Y,*args,**kwargs)
@@ -280,7 +280,7 @@ def start_server(slurm_script=None, ipcluster="ipcluster", ncpus = None):
         number of processors
     ipcluster : str
         ipcluster binary file name; requires 4 path separators on Windows. ipcluster="C:\\\\Anaconda2\\\\Scripts\\\\ipcluster.exe"
-         Default: "ipcluster"    
+         Default: "ipcluster"
     '''
     sys.stdout.write("Starting cluster...")
     sys.stdout.flush()
@@ -354,7 +354,7 @@ def stop_server( ipcluster='ipcluster',pdir=None,profile=None):
     except:
         print('NOT SLURM')
         is_slurm = False
-        
+
     if is_slurm:
 
         if pdir is None and profile is None:
@@ -405,21 +405,21 @@ def stop_server( ipcluster='ipcluster',pdir=None,profile=None):
 #%%
 def setup_cluster(backend = 'local',n_processes = None,single_thread = False):
     ''' Restart if necessary the pipyparallel cluster, and manages the case of SLURM
-    
+
     '''
     #backend; 'local' or 'SLURM'. SLURM is experimental! You need to modify the script SLURM/slurmStart.sh
     if n_processes is None:
-        if backend == 'SLURM':            
+        if backend == 'SLURM':
             n_processes = np.int(os.environ.get('SLURM_NPROCS'))
         else:
             # roughly number of cores on your machine minus 1
-            
+
             n_processes = np.maximum(np.int(psutil.cpu_count()), 1)
-        
+
     print(('using ' + str(n_processes) + ' processes'))
-   
-    
-    
+
+
+
     if single_thread:
         dview = None
         c = None
@@ -427,12 +427,10 @@ def setup_cluster(backend = 'local',n_processes = None,single_thread = False):
         try:
             c.close()
         except:
-            print('C was not existing, creating one')
-            
-        print("Stopping  cluster to avoid unnencessary use of memory....")
-        
+            print('Client did not exist, creating one')
+
         sys.stdout.flush()
-        
+
         if backend == 'SLURM':
             try:
                 stop_server(is_slurm=True)
@@ -446,9 +444,8 @@ def setup_cluster(backend = 'local',n_processes = None,single_thread = False):
             stop_server()
             start_server(ncpus=n_processes)
             c = Client()
-    
+
         print(('Using ' + str(len(c)) + ' processes'))
         dview = c[:len(c)]
-    
-    return c,dview,n_processes                 
-    
+
+    return c,dview,n_processes

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -201,6 +201,7 @@ class CNMF(object):
                                alpha_snmf=self.alpha_snmf)
         self.options = options
 
+
         if self.rf is None:  # no patches
             print('preprocessing ...')
             Yr, sn, g, psx = preprocess_data(Yr, dview=self.dview, **options['preprocess_params'])
@@ -241,8 +242,7 @@ class CNMF(object):
                     idx_components, idx_components_bad, fitness_raw, fitness_delta, r_values = components_evaluation.estimate_components_quality(
                         traces, Y, self.A, np.array(self.C), self.b_in, self.f_in, final_frate = final_frate, Npeaks=Npeaks, r_values_min=r_values_min, fitness_min=fitness_min, fitness_delta_min=fitness_delta_min, return_all = True, N = 5)
 
-                    print(('Keeping ' + str(len(idx_components)) +
-                           ' and discarding  ' + str(len(idx_components_bad))))
+                    print('Keeping', str(len(idx_components)), 'and discarding ', str(len(idx_components_bad)))
 
                     self.C = self.C[idx_components]
                     self.A = self.A[:,idx_components]
@@ -311,10 +311,6 @@ class CNMF(object):
 
             if self.only_init:
                 options['patch_params']['only_init'] = True
-
-            if self.alpha_snmf is not None:
-                options['init_params']['alpha_snmf'] = self.alpha_snmf
-
 
             A, C, YrA, b, f, sn, optional_outputs = run_CNMF_patches(images.filename, dims + (T,), options, rf=self.rf, stride=self.stride,
                                                                      dview=self.dview, memory_fact=self.memory_fact, gnb=self.gnb)

--- a/caiman/source_extraction/cnmf/cnmf.py
+++ b/caiman/source_extraction/cnmf/cnmf.py
@@ -5,7 +5,7 @@ Constrained Nonnegative Matrix Factorization
 Created on Fri Aug 26 15:44:32 2016
 
 @author: agiovann
- 
+
 
 """
 from __future__ import division
@@ -37,7 +37,7 @@ class CNMF(object):
                                         method_deconvolution = 'oasis', n_pixels_per_process = 4000, block_size = 20000,
                                         check_nan = True, skip_refinement = False, normalize_init=True, options_local_NMF = None,
                                         remove_very_bad_comps = False):
-        """ 
+        """
         Constructor of the CNMF method
 
         Parameters:
@@ -68,11 +68,11 @@ class CNMF(object):
         ssub: int
             downsampleing factor in space
 
-        tsub: int 
+        tsub: int
              downsampling factor in time
 
         p_ssub: int
-            downsampling factor in space for patches 
+            downsampling factor in space for patches
 
         method_init: str
            can be greedy_roi or sparse_nmf
@@ -80,8 +80,8 @@ class CNMF(object):
         alpha_snmf: float
             weight of the sparsity regularization
 
-        p_tsub: int 
-             downsampling factor in time for patches     
+        p_tsub: int
+             downsampling factor in time for patches
 
         rf: int
             half-size of the patches in pixels. rf=25, patches are 50x50
@@ -95,38 +95,38 @@ class CNMF(object):
         memory_fact: float
             unitless number accounting how much memory should be used. You will need to try different values to see which one would work the default is OK for a 16 GB system
 
-        N_samples_fitness: int 
+        N_samples_fitness: int
             number of samples over which exceptional events are computed (See utilities.evaluate_components)
 
         only_init_patch= boolean
             only run initialization on patches
-        
+
         method_deconvolution = 'oasis' or 'cvxpy'
-            method used for deconvolution. Suggested 'oasis' see  
+            method used for deconvolution. Suggested 'oasis' see
             Friedrich J, Zhou P, Paninski L. Fast Online Deconvolution of Calcium Imaging Data. PLoS Comput Biol. 2017; 13(3):e1005423.
-        
-        n_pixels_per_process: int. 
+
+        n_pixels_per_process: int.
             Number of pixels to be processed in parallel per core (no patch mode). Decrease if memory problems
-        
-        block_size: int. 
+
+        block_size: int.
             Number of pixels to be used to perform residual computation in blocks. Decrease if memory problems
-        
-        check_nan: Boolean. 
+
+        check_nan: Boolean.
             Check if file contains NaNs (costly for very large files so could be turned off)
-        
-        skip_refinement: 
+
+        skip_refinement:
             Bool. If true it only performs one iteration of update spatial update temporal instead of two
-        
-        normalize_init=Bool. 
+
+        normalize_init=Bool.
             Differences in intensities on the FOV might caus troubles in the initialization when patches are not used, so each pixels can be normalized by its median intensity
-        
-        options_local_NMF: 
+
+        options_local_NMF:
             experimental, not to be used
 
         remove_very_bad_comps:Bool
-            whether to remove components with very low values of component quality directly on the patch. This might create some minor imprecisions. 
+            whether to remove components with very low values of component quality directly on the patch. This might create some minor imprecisions.
             Howeverm benefits can be considerable if done because if many components (>2000) are created and joined together, operation that causes a bottleneck
-        
+
         Returns:
         --------
         self
@@ -148,9 +148,9 @@ class CNMF(object):
         self.method_init= method_init
         self.n_processes=n_processes
         self.rf=rf # half-size of the patches in pixels. rf=25, patches are 50x50
-        self.stride=stride #amount of overlap between the patches in pixels   
+        self.stride=stride #amount of overlap between the patches in pixels
         self.memory_fact = memory_fact  #unitless number accounting how much memory should be used. You will need to try different values to see which one would work the default is OK for a 16 GB system
-        self.gnb = gnb                        
+        self.gnb = gnb
         self.do_merge=do_merge
         self.alpha_snmf=alpha_snmf
         self.only_init=only_init_patch
@@ -186,9 +186,8 @@ class CNMF(object):
         """
         T = images.shape[0]
         dims = images.shape[1:]
-        Y = np.transpose(images, list(range(1, len(dims) + 1)) + [0])
-        Yr = np.transpose(np.reshape(images, (T, -1), order='F'))
-        print((T,) + dims)
+        Y = np.transpose(images, list(range(1, len(dims) + 1)) + [0]) # (x, y[, z], t)
+        Yr = np.transpose(np.reshape(images, (T, -1), order='F')) # (t, pixels)
 
         # Make sure filename is pointed correctly (numpy sets it to None sometimes)
         Y.filename = images.filename
@@ -197,43 +196,41 @@ class CNMF(object):
         options = CNMFSetParms(Y, self.n_processes, p=self.p, gSig=self.gSig, K=self.k, ssub=self.ssub, tsub=self.tsub,
                                p_ssub=self.p_ssub, p_tsub=self.p_tsub, method_init=self.method_init,
                                n_pixels_per_process=self.n_pixels_per_process, block_size=self.block_size,
-                               check_nan=self.check_nan, nb=self.gnb, normalize_init = self.normalize_init, options_local_NMF = self.options_local_NMF, remove_very_bad_comps = self.remove_very_bad_comps)
-
+                               check_nan=self.check_nan, nb=self.gnb, normalize_init=self.normalize_init,
+                               options_local_NMF=self.options_local_NMF, remove_very_bad_comps=self.remove_very_bad_comps,
+                               alpha_snmf=self.alpha_snmf)
         self.options = options
-        
+
         if self.rf is None:  # no patches
             print('preprocessing ...')
             Yr, sn, g, psx = preprocess_data(Yr, dview=self.dview, **options['preprocess_params'])
-            
+
             if self.Ain is None:
                 print('initializing ...')
-                if self.alpha_snmf is not None:
-                    options['init_params']['alpha_snmf'] = self.alpha_snmf
-
                 self.Ain, self.Cin, self.b_in, self.f_in, center = initialize_components(
                     Y, **options['init_params'])
-                
+
 
 
             if self.only_init: # only return values after initialization
-                
+
                 nA = np.squeeze(np.array(np.sum(np.square(self.Ain),axis=0)))
-        
+
                 nr=nA.size
                 Cin=scipy.sparse.coo_matrix(self.Cin)
-                
-                
-                
-                
+
+
+
+
                 YA = (self.Ain.T.dot(Yr).T)*scipy.sparse.spdiags(old_div(1.,nA),0,nr,nr)
                 AA = ((self.Ain.T.dot(self.Ain))*scipy.sparse.spdiags(old_div(1.,nA),0,nr,nr))
-                
-                self.YrA = YA - Cin.T.dot(AA)      
-                self.A = self.Ain 
-                self.C = Cin.todense() 
-                
+
+                self.YrA = YA - Cin.T.dot(AA)
+                self.A = self.Ain
+                self.C = Cin.todense()
+
                 if self.remove_very_bad_comps:
-                
+
                     final_frate = 3
                     r_values_min = 0.5  # threshold on space consistency
                     fitness_min = -15  # threshold on time variability
@@ -242,28 +239,27 @@ class CNMF(object):
                     traces = np.array(self.C)
 #                    import pdb;pdb.set_trace()
                     idx_components, idx_components_bad, fitness_raw, fitness_delta, r_values = components_evaluation.estimate_components_quality(
-                        traces, Y, self.A, np.array(self.C), self.b_in, self.f_in, final_frate = final_frate, Npeaks=Npeaks, r_values_min=r_values_min, fitness_min=fitness_min, fitness_delta_min=fitness_delta_min, return_all = True, N = 5)                    
-    
+                        traces, Y, self.A, np.array(self.C), self.b_in, self.f_in, final_frate = final_frate, Npeaks=Npeaks, r_values_min=r_values_min, fitness_min=fitness_min, fitness_delta_min=fitness_delta_min, return_all = True, N = 5)
+
                     print(('Keeping ' + str(len(idx_components)) +
                            ' and discarding  ' + str(len(idx_components_bad))))
-                    
-                    self.C = self.C[idx_components]                    
-                    self.A = self.A[:,idx_components]                                  
+
+                    self.C = self.C[idx_components]
+                    self.A = self.A[:,idx_components]
                     self.YrA = self.YrA[:,idx_components]
-                                                           
-                    
-                
-                self.sn = sn                    
+
+
+                self.sn = sn
                 self.b = self.b_in
-                self.f = self.f_in    
-                self.g = g    
+                self.f = self.f_in
+                self.g = g
                 self.bl = None
                 self.c1 = None
                 self.neurons_sn = None
-                
+
                 return self
 
-            
+
             print('update spatial ...')
             A, b, Cin, self.f_in = update_spatial_components(Yr, self.Cin, self.f_in, self.Ain, sn=sn, dview=self.dview, **options['spatial_params'])
 
@@ -286,10 +282,8 @@ class CNMF(object):
                     A, C, nr, merged_ROIs, S, bl, c1, sn1, g1 = merge_components(Yr, A, b, C, f, S, sn, options['temporal_params'], options[
                                                                                  'spatial_params'], dview=self.dview, bl=bl, c1=c1, sn=neurons_sn, g=g, thr=self.merge_thresh, mx=50, fast_merge=True)
 
-                print((A.shape))
 
                 print('update spatial ...')
-
                 A, b, C, f = update_spatial_components(
                     Yr, C, f, A, sn=sn, dview=self.dview, **options['spatial_params'])
 
@@ -300,13 +294,13 @@ class CNMF(object):
                     Yr, A, b, C, f, dview=self.dview, bl=None, c1=None, sn=None, g=None, **options['temporal_params'])
 
             else:
-                
+
                     C, f, S, bl, c1, neurons_sn, g1, YrA = C, f, S, bl, c1, neurons_sn, g, YrA
 
-            
-         
+
+
         else:  # use patches
-            
+
             if self.stride is None:
                 self.stride = np.int(self.rf * 2 * .1)
                 print(('**** Setting the stride to 10% of 2*rf automatically:' + str(self.stride)))
@@ -339,16 +333,6 @@ class CNMF(object):
             print("update temporal")
             C, A, b, f, S, bl, c1, neurons_sn, g1, YrA = update_temporal_components(
                 Yr, A, b, C, f, dview=self.dview, bl=None, c1=None, sn=None, g=None, **options['temporal_params'])
-
-#           idx_components, fitness, erfc ,r_values, num_significant_samples = evaluate_components(Y,C+YrA,A,N=self.N_samples_fitness,robust_std=self.robust_std,thresh_finess=self.fitness_threshold)
-#           sure_in_idx= idx_components[np.logical_and(np.array(num_significant_samples)>0 ,np.array(r_values)>=self.corr_threshold)]
-#
-#           print ('Keeping ' + str(len(sure_in_idx)) + ' components out of ' + str(len(idx_components)))
-#
-#
-#           A=A[:,sure_in_idx]
-#           C=C[sure_in_idx,:]
-#           YrA=YrA[sure_in_idx]
 
         self.A=A
         self.C=C

--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -552,7 +552,7 @@ def finetune(Y, cin, nIter=5):
 #%%
 
 
-def imblur(Y, sig=5, siz=11, nDimBlur=None, kernel=None, opencv = True):
+def imblur(Y, sig=5, siz=11, nDimBlur=None, kernel=None, opencv = False):
     """Spatial filtering with a Gaussian or user defined kernel
     The parameters are specified in GreedyROI
     """

--- a/caiman/source_extraction/cnmf/initialization.py
+++ b/caiman/source_extraction/cnmf/initialization.py
@@ -47,10 +47,10 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
     normalize_init: [optional] bool
         Whether to normalize_init data before running the initialization
     img: optional [np 2d array]
-        Image with which to normalize. If not present use the mean + offset 
-    method: str  
-        Initialization method 'greedy_roi' or 'sparse_nmf' 
-    max_iter_snmf: int 
+        Image with which to normalize. If not present use the mean + offset
+    method: str
+        Initialization method 'greedy_roi' or 'sparse_nmf'
+    max_iter_snmf: int
         Maximum number of sparse NMF iterations
     alpha_snmf: scalar
         Sparsity penalty
@@ -74,10 +74,10 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
     if method == 'local_nmf':
         tsub_lnmf = tsub
         ssub_lnmf = ssub
-        tsub = 1 
+        tsub = 1
         ssub = 1
-        
-        
+
+
     if gSiz is None:
         gSiz = 2 * np.asarray(gSig) + 1
 
@@ -93,7 +93,7 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
             img += np.median(img)
 
         Y = old_div(Y, np.reshape(img, d + (-1,), order='F'))
-        alpha_snmf /= np.mean(img)
+        if alpha_snmf is not None: alpha_snmf /= np.mean(img)
 
     # spatial downsampling
     mean_val = np.mean(Y)
@@ -112,10 +112,10 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
         if use_hals:
             print('Refining Components...')
             Ain, Cin, b_in, f_in = hals(Y_ds, Ain, Cin, b_in, f_in, maxIter=maxIter)
-            
-        
+
+
     elif method == 'sparse_nmf':
-        
+
         Ain, Cin, _, b_in, f_in = sparseNMF(Y_ds, nr=K, nb=nb, max_iter_snmf=max_iter_snmf, alpha=alpha_snmf,
                                             sigma_smooth=sigma_smooth_snmf, remove_baseline=True, perc_baseline=perc_baseline_snmf)
 #        print np.sum(Ain), np.sum(Cin)
@@ -123,20 +123,20 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
 #        Ain, Cin, b_in, f_in = hals(Y_ds, Ain, Cin, b_in, f_in, maxIter=maxIter)
 #        print np.sum(Ain), np.sum(Cin)
     elif method == 'pca_ica':
-        
+
         Ain, Cin, _, b_in, f_in = ICA_PCA(Y_ds, nr = K, sigma_smooth=sigma_smooth_snmf,  truncate = 2, fun='logcosh',\
                                           max_iter=max_iter_snmf, tol=1e-10,remove_baseline=True, perc_baseline=perc_baseline_snmf, nb=nb)
-        
+
     elif method == 'local_nmf':
-        from SourceExtraction.CNMF4Dendrites import CNMF4Dendrites    
+        from SourceExtraction.CNMF4Dendrites import CNMF4Dendrites
         from SourceExtraction.AuxilaryFunctions import GetCentersData
         #Get initialization for components center
         print(Y_ds.transpose([2,0,1]).shape)
         if options_local_NMF is None:
-            
+
              raise Exception('You need to define arguments for local NMF')
-           
-            
+
+
 #            #Define CNMF parameters
 #            mbs=[tsub_lnmf] # temporal downsampling of data in intial phase of NMF
 #            ds=ssub_lnmf # spatial downsampling of data in intial phase of NMF. Ccan be an integer or a list of the size of spatial dimensions
@@ -144,11 +144,11 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
 #            #repeats=1 # how many repeations to run NMF algorithm
 #            iters0=[5] #30 number of intial NMF iterations, in which we downsample data and add components
 #            iters=20 #100 number of main NMF iterations, in which we fine tune the components on the full data
-#            lam1_s=10# l1 regularization parameter initialization (for increased sparsity). If zero, we have no l1 sparsity penalty        
+#            lam1_s=10# l1 regularization parameter initialization (for increased sparsity). If zero, we have no l1 sparsity penalty
 #            bkg_per=0.1 # intialize of background shape at this percentile (over time) of video
 #            sig=Y_ds.shape[:-1] # estiamte size of neuron - bounding box is 3 times this size. If larger then data, we have no bounding box.
 #            MergeThreshold_activity=0.85#merge components if activity is correlated above the this threshold (and sufficiently close)
-#            MergeThreshold_shapes=0.99 #merge components if activity is correlated above the this threshold (and sufficiently close)                    
+#            MergeThreshold_shapes=0.99 #merge components if activity is correlated above the this threshold (and sufficiently close)
 #            Connected=True # should we constrain all spatial component to be connected?
 #            SigmaMask=3  # if not [], then update masks so that they are non-zero a radius of SigmaMasks around previous non-zero support of shapes
 
@@ -156,7 +156,7 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
 
 #            NumCent=400 # Max number of centers to import from Group Lasso intialization - if 0, we don't run group lasso
 #            cent=GetCentersData(Y_ds.transpose([2,0,1]),NumCent)
-#            
+#
 #            #Define CNMF parameters
 #            mbs=[10] # temporal downsampling of data in intial phase of NMF
 #            ds=1 # spatial downsampling of data in intial phase of NMF. Ccan be an integer or a list of the size of spatial dimensions
@@ -172,37 +172,37 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
 #            bkg_per=0.1 # intialize of background shape at this percentile (over time) of video
 #            sig=Y_ds.shape[:-1] # estiamte size of neuron - bounding box is 3 times this size. If larger then data, we have no bounding box.
 #            MergeThreshold_activity=0.85#merge components if activity is correlated above the this threshold (and sufficiently close)
-#            MergeThreshold_shapes=0.99 #merge components if activity is correlated above the this threshold (and sufficiently close)        
+#            MergeThreshold_shapes=0.99 #merge components if activity is correlated above the this threshold (and sufficiently close)
 #            Connected=True # should we constrain all spatial component to be connected?
 #            SigmaMask=3  # if not [], then update masks so that they are non-zero a radius of SigmaMasks around previous non-zero support of shapes
-        
+
 #            cnmf_obj=CNMF4Dendrites(sig=sig, verbose=True,adaptBias=True,TargetAreaRatio=TargetAreaRatio,
-#                     Connected=Connected, SigmaMask=SigmaMask,bkg_per=bkg_per,iters=iters,iters0=iters0, mbs=mbs, 
-#                     ds=ds,lam1_s=lam1_s,MergeThreshold_activity=MergeThreshold_activity,MergeThreshold_shapes=MergeThreshold_shapes)  
+#                     Connected=Connected, SigmaMask=SigmaMask,bkg_per=bkg_per,iters=iters,iters0=iters0, mbs=mbs,
+#                     ds=ds,lam1_s=lam1_s,MergeThreshold_activity=MergeThreshold_activity,MergeThreshold_shapes=MergeThreshold_shapes)
         else:
-            
+
             NumCent=options_local_NMF.pop('NumCent', None) # Max number of centers to import from Group Lasso intialization - if 0, we don't run group lasso
-            cent=GetCentersData(Y_ds.transpose([2,0,1]),NumCent) 
+            cent=GetCentersData(Y_ds.transpose([2,0,1]),NumCent)
             sig=Y_ds.shape[:-1] # estiamte size of neuron - bounding box is 3 times this size. If larger then data, we have no bounding box.
-            cnmf_obj=CNMF4Dendrites(sig=sig, verbose=True,adaptBias=True,**options_local_NMF)  
-            
+            cnmf_obj=CNMF4Dendrites(sig=sig, verbose=True,adaptBias=True,**options_local_NMF)
+
         #Define CNMF parameters
         _, _, _ =cnmf_obj.fit(np.array(Y_ds.transpose([2,0,1]),dtype = np.float),cent)
-        
+
         Ain = cnmf_obj.A
         Cin = cnmf_obj.C
         b_in = cnmf_obj.b
-        f_in = cnmf_obj.f 
-        
+        f_in = cnmf_obj.f
+
 #        Cin, _, b_in, f_in = ICA_PCA(Y_ds, nr = K, sigma_smooth=sigma_smooth_snmf,  truncate = 2, fun='logcosh',\
 #                                          max_iter=max_iter_snmf, tol=1e-10,remove_baseline=True, perc_baseline=perc_baseline_snmf, nb=nb)
-    
+
     else:
-        
+
         print(method)
         raise Exception("Unsupported method")
-    
-    
+
+
     K = np.shape(Ain)[-1]
     ds = Y_ds.shape[:-1]
 
@@ -249,21 +249,21 @@ def initialize_components(Y, K=30, gSig=[5, 5], gSiz=None, ssub=1, tsub=1, nIter
         # b_in = np.atleast_2d(b_in * img.flatten('F')) #np.reshape(img,
         # (np.prod(d), -1),order='F')
         Y = Y * np.reshape(img, d + (-1,), order='F')
-       
-    
+
+
     return Ain, Cin, b_in, f_in, center
 
 #%%
 def ICA_PCA(Y_ds, nr, sigma_smooth=(.5, .5, .5),  truncate = 2, fun='logcosh', max_iter=1000, tol=1e-10,remove_baseline=True, perc_baseline=20, nb=1):
     """ Initialization using ICA and PCA. DOES NOT WORK WELL WORK IN PROGRESS"
-    
+
     Parameters:
     -----------
-    
+
     Returns:
     --------
-        
-    
+
+
     """
     m = scipy.ndimage.gaussian_filter(np.transpose(Y_ds, [2, 0, 1]), sigma=sigma_smooth, mode='nearest', truncate=truncate)
     if remove_baseline:
@@ -272,13 +272,13 @@ def ICA_PCA(Y_ds, nr, sigma_smooth=(.5, .5, .5),  truncate = 2, fun='logcosh', m
     else:
         bl = 0
         m1 = m
-        
+
     pca_comp = nr
-    
+
     T, d1, d2 = np.shape(m1)
     d = d1 * d2
     yr = np.reshape(m1, [T, d], order='F')
-    
+
     [U,S,V] = scipy.sparse.linalg.svds(yr,pca_comp)
     S = np.diag(S);
 #        whiteningMatrix = np.dot(scipy.linalg.inv(np.sqrt(S)),U.T)
@@ -292,35 +292,35 @@ def ICA_PCA(Y_ds, nr, sigma_smooth=(.5, .5, .5),  truncate = 2, fun='logcosh', m
     A_in = f_ica.mixing_
     A_in = np.dot(A_in,whitesig)
 
-    
+
     masks = np.reshape(A_in.T,(d1,d2,pca_comp),order = 'F').transpose([2,0,1])
-    
-    
+
+
 #    pl.figure()
  #   caiman.utils.visualization.matrixMontage(np.array(masks))
     masks = np.array(caiman.base.rois.extractROIsFromPCAICA(masks)[0])
 #    pl.pause(3)
-    
-    
+
+
     if masks.size > 0:
 
         C_in = caiman.base.movies.movie(m1).extract_traces_from_masks(np.array(masks)).T
         A_in = np.reshape(masks,[-1,d1*d2],order = 'F').T
-        
+
 #        pl.figure()
 #        pl.imshow(np.reshape(A_in.sum(1),[d1,d2],order = 'F'))
 #        pl.pause(3)
 
-    
+
     else:
-        
-        A_in = np.zeros([d1*d2,pca_comp])     
+
+        A_in = np.zeros([d1*d2,pca_comp])
         C_in = np.zeros([pca_comp,T])
 
 
 
     m1 = yr.T - A_in.dot(C_in) + np.maximum(0, bl.flatten())[:, np.newaxis]
-    
+
     model = NMF(n_components=nb, init='random', random_state=0)
 
     b_in = model.fit_transform(np.maximum(m1, 0))
@@ -346,7 +346,7 @@ def sparseNMF(Y_ds, nr,  max_iter_snmf=500, alpha=10e2, sigma_smooth=(.5, .5, .5
     perc_baseline_snmf:
         percentile to remove frmo movie before NMF
     nb: int
-        Number of background components    
+        Number of background components
 
     Returns:
     -------
@@ -400,12 +400,12 @@ def sparseNMF(Y_ds, nr,  max_iter_snmf=500, alpha=10e2, sigma_smooth=(.5, .5, .5
     f_in = model.components_.squeeze()
 #    for ccount,caaa in enumerate(A.T):
 #        pl.subplot(3,3,ccount+1)
-#        pl.imshow(np.reshape(caaa,[d1,d2],order = 'F'))    
-        
+#        pl.imshow(np.reshape(caaa,[d1,d2],order = 'F'))
+
 #    pl.subplot(2,2,1)
 #    pl.imshow(np.reshape(b_in,[d1,d2],order = 'F'))
 #    pl.subplot(2,2,2)
-#    pl.imshow(np.reshape(A_in.mean(axis = 1),[d1,d2],order = 'F'))    
+#    pl.imshow(np.reshape(A_in.mean(axis = 1),[d1,d2],order = 'F'))
 #    pl.subplot(2,2,3)
 #    pl.imshow(np.mean(np.maximum(0, m - bl),0))
 #    pl.subplot(2,2,4)
@@ -417,7 +417,7 @@ def sparseNMF(Y_ds, nr,  max_iter_snmf=500, alpha=10e2, sigma_smooth=(.5, .5, .5
 #        f = np.maximum(b.T.dot(scipy.linalg.solve(scipy.linalg.norm(b).T**2,Y.T),0);
 #        b = np.maximum(Y.dot(scipy.linalg.solve(scipy.linalg.norm(f).T**2,f.T),0);
 #    end
-    
+
     return A_in, C_in, center, b_in, f_in
 
 #%%
@@ -557,8 +557,6 @@ def imblur(Y, sig=5, siz=11, nDimBlur=None, kernel=None, opencv = True):
     The parameters are specified in GreedyROI
     """
 #    import cv2
-    
-
     X = np.zeros(np.shape(Y))
 
     if kernel is None:
@@ -594,11 +592,11 @@ def imblur(Y, sig=5, siz=11, nDimBlur=None, kernel=None, opencv = True):
         if opencv and nDimBlur == 2:
             if X.ndim > 2:
                 for frame in range(X.shape[-1]):
-                    X[:,:,frame] = cv2.GaussianBlur(X[:,:,frame],tuple(siz),sig[0],sig[1],cv2.BORDER_CONSTANT,0)               
-                
+                    X[:,:,frame] = cv2.GaussianBlur(X[:,:,frame],tuple(siz),sig[0],sig[1],cv2.BORDER_CONSTANT,0)
+
             else:
-                X = cv2.GaussianBlur(X,tuple(siz),sig[0],sig[1],cv2.BORDER_CONSTANT,0) 
-        else:                
+                X = cv2.GaussianBlur(X,tuple(siz),sig[0],sig[1],cv2.BORDER_CONSTANT,0)
+        else:
             for i in range(nDimBlur):
                 h = np.exp(
                     old_div(-np.arange(-np.floor(old_div(siz[i], 2)), np.floor(old_div(siz[i], 2)) + 1)**2, (2 * sig[i]**2)))
@@ -606,7 +604,7 @@ def imblur(Y, sig=5, siz=11, nDimBlur=None, kernel=None, opencv = True):
                 shape = [1] * len(Y.shape)
                 shape[i] = -1
                 X = correlate(X, h.reshape(shape), mode='constant')
-                
+
 
     else:
         X = correlate(Y, kernel[..., np.newaxis], mode='constant')
@@ -630,7 +628,7 @@ def hals(Y, A, C, b, f, bSiz=3, maxIter=5):
        b:      (d1*d2[*d3]) X nb, initial value of background spatial component
        f:      nb X T, initial value of background temporal component
        bSiz:   int or tuple of int
-       blur size. A box kernel (bSiz X bSiz [X bSiz]) (if int) or bSiz (if tuple) will 
+       blur size. A box kernel (bSiz X bSiz [X bSiz]) (if int) or bSiz (if tuple) will
        be convolved with each neuron's initial spatial component, then all nonzero
        pixels will be picked as pixels to be updated, and the rest will be
        forced to be 0.

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -20,7 +20,10 @@ import scipy
 from ...mmapping import parallel_dot_product
 
 #%%
-def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], ssub=2, tsub=2, p=2, p_ssub=2, p_tsub=2, thr=0.8, method_init= 'greedy_roi', nb = 1, n_pixels_per_process = 1000, block_size = 1000, check_nan = True, normalize_init = True, options_local_NMF = None, remove_very_bad_comps = False):
+def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], ssub=2, tsub=2, p=2, p_ssub=2, p_tsub=2,
+                 thr=0.8, method_init='greedy_roi', nb=1, n_pixels_per_process=1000, block_size=1000,
+                 check_nan=True, normalize_init=True, options_local_NMF=None, remove_very_bad_comps=False,
+                 alpha_snmf=None):
     """Dictionary for setting the CNMF parameters.
     Any parameter that is not set get a default value specified
     by the dictionary default options
@@ -34,12 +37,12 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], ssub=2, tsub=2, p=2, p_ssub=
     print(('using ' + str(n_processes) + ' processes'))
 #    n_pixels_per_process = np.prod(dims) / n_processes  # how to subdivide the work among processes
 
-    if n_pixels_per_process is None:                                  
+    if n_pixels_per_process is None:
         avail_memory_per_process = np.array(psutil.virtual_memory()[1])/2.**30/n_processes
         mem_per_pix = 3.6977678498329843e-09
         n_pixels_per_process = np.int(avail_memory_per_process/8./mem_per_pix/T)
         n_pixels_per_process = np.int(np.minimum(n_pixels_per_process,np.prod(dims) // n_processes))
-    
+
     if block_size is None:
         block_size = n_pixels_per_process
 
@@ -54,7 +57,7 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], ssub=2, tsub=2, p=2, p_ssub=
         'skip_refinement' : False,
         'remove_very_bad_comps' : remove_very_bad_comps
     }
-    
+
     options['preprocess_params'] = {'sn': None,                  # noise level for each pixel
                                     # range of normalized frequencies over which to average
                                     'noise_range': [0.25, 0.5],
@@ -72,7 +75,7 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], ssub=2, tsub=2, p=2, p_ssub=
                                     }
     gSig = gSig if gSig is not None else [-1, -1]
 
-    options['init_params'] = {'K': K,                  # number of components                                             
+    options['init_params'] = {'K': K,                  # number of components
                               'gSig': gSig,                               # size of bounding box
                               'gSiz': [int(round((x * 2) + 1)) for x in gSig],
                               'ssub': ssub,             # spatial downsampling factor
@@ -80,16 +83,16 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], ssub=2, tsub=2, p=2, p_ssub=
                               'nIter': 5,               # number of refinement iterations
                               'kernel': None,           # user specified template for greedyROI
                               'maxIter': 5,              # number of HALS iterations
-                              'method' : method_init,     # can be greedy_roi or sparse_nmf, local_NMF 
+                              'method' : method_init,     # can be greedy_roi or sparse_nmf, local_NMF
                               'max_iter_snmf' : 500,
-                              'alpha_snmf' : 10e2,
+                              'alpha_snmf' : alpha_snmf,
                               'sigma_smooth_snmf' : (.5,.5,.5),
                               'perc_baseline_snmf': 20,
                               'nb' : nb,                 # number of background components
                               'normalize_init': normalize_init,        # whether to pixelwise equalize the movies during initialization
                               'options_local_NMF': options_local_NMF # dictionary with parameters to pass to local_NMF initializaer
                               }
-    
+
     options['spatial_params'] = {
         'dims': dims,                   # number of rows, columns [and depths]
         # method for determining footprint of spatial components ('ellipse' or 'dilate')
@@ -102,12 +105,12 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], ssub=2, tsub=2, p=2, p_ssub=
         'nrgthr' : 0.9999,                              # Energy threshold
         'extract_cc' : True,                            # Flag to extract connected components (might want to turn to False for dendritic imaging)
         'se' : np.ones((3,)*len(dims), dtype=np.uint8),           # Morphological closing structuring element
-        'ss' : np.ones((3,)*len(dims), dtype=np.uint8),           # Binary element for determining connectivity            
+        'ss' : np.ones((3,)*len(dims), dtype=np.uint8),           # Binary element for determining connectivity
         'nb' : nb,                                      # number of background components
-        'method_ls':'lasso_lars',                        # 'nnls_L0'. Nonnegative least square with L0 penalty        
+        'method_ls':'lasso_lars',                        # 'nnls_L0'. Nonnegative least square with L0 penalty
                                                         #'lasso_lars' lasso lars function from scikit learn
-                                                        #'lasso_lars_old' lasso lars from old implementation, will be deprecated 
-                                                        
+                                                        #'lasso_lars_old' lasso lars from old implementation, will be deprecated
+
         }
     options['temporal_params'] = {
         'ITER': 2,                   # block coordinate descent iterations
@@ -125,7 +128,7 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], ssub=2, tsub=2, p=2, p_ssub=
         'noise_method': 'mean',   # averaging method ('mean','median','logmexp')
         'lags': 5,                   # number of autocovariance lags to be considered for time constant estimation
         'fudge_factor': .96,         # bias correction factor (between 0 and 1, close to 1)
-        'nb' : nb,                   # number of background components               
+        'nb' : nb,                   # number of background components
         'verbosity': False,
         'block_size' : block_size # number of pixels to process at the same time for dot product. Make it smaller if memory problems
     }
@@ -136,11 +139,11 @@ def CNMFSetParms(Y, n_processes, K=30, gSig=[5, 5], ssub=2, tsub=2, p=2, p_ssub=
 #%%
 def computeDFF_traces(Yr, A, C,  bl, quantileMin = 8, frames_window = 200):
     extract_DF_F(Yr, A, C,  bl, quantileMin , frames_window )
-    
-#%%    
-def extract_DF_F(Yr, A, C,  bl, quantileMin = 8, frames_window = 200, block_size = 400, dview = None):    
+
+#%%
+def extract_DF_F(Yr, A, C,  bl, quantileMin = 8, frames_window = 200, block_size = 400, dview = None):
         """ Compute DFF function from cnmf output. Disclaimer: it might be memory inefficient
-        
+
         Parameters:
         -----------
         Yr: ndarray (2D)
@@ -152,18 +155,18 @@ def extract_DF_F(Yr, A, C,  bl, quantileMin = 8, frames_window = 200, block_size
         bl: ndarray
             baseline for each component (from cnmf cnm.bl)
         quantile_min: float
-            quantile minimum of the 
+            quantile minimum of the
         frammes_window: int
-            number of frames for running quantile                        
-            
-        """        
+            number of frames for running quantile
+
+        """
         nA = np.array(np.sqrt(A.power(2).sum(0)).T);
         A = scipy.sparse.coo_matrix(A/nA.T)
         C = C*nA
         bl = (bl*nA.T).squeeze()
         nA = np.array(np.sqrt(A.power(2).sum(0)).T);
-        
-        
+
+
         T = C.shape[-1]
 #            AY = mm_fun(A,Y);
     #        AY = A.T.dot(Yr)
@@ -174,34 +177,34 @@ def extract_DF_F(Yr, A, C,  bl, quantileMin = 8, frames_window = 200, block_size
             else:
                 print('Using thread. If memory issues set block_size larger than 500')
                 dview_res = dview
-    
+
             AY = parallel_dot_product(Yr, A, dview=dview_res, block_size=block_size,
-                                      transpose=True).T 
+                                      transpose=True).T
         else:
             AY = A.T.dot(Yr)
-        
-        
+
+
         bas_val = bl[None,:]
         Bas = np.repeat(bas_val,T,0).T
-                    
-        
+
+
         AA = A.T.dot(A);
         AA.setdiag(0)
         Cf = (C-Bas)*(nA**2)
         C2 = AY - AA.dot(C);
-        
-        
+
+
         if frames_window is None or  frames_window > T:
             Df = np.percentile(C2,quantileMin, axis = 1)
-            C_df = Cf/Df[:,None]              
-           
+            C_df = Cf/Df[:,None]
+
         else:
             Df = scipy.ndimage.percentile_filter(C2, quantileMin, (frames_window,1))
             C_df = Cf/Df
-        
-       
+
+
         return C_df
-                
+
 #%%
 def manually_refine_components(Y, xxx_todo_changeme, A, C, Cn, thr=0.9, display_numbers=True, max_number=None, cmap=None, **kwargs):
     """Plots contour of spatial components against a background image and allows to interactively add novel components by clicking with mouse
@@ -394,8 +397,8 @@ def app_vertex_cover(A):
         L.append(u)
 
     return np.asarray(L)
-    
-    
+
+
 #%%
 
 
@@ -534,10 +537,10 @@ def update_order_greedy(A,flag_AA = True):
     Input:
      -------
      A:       sparse crc matrix
-              matrix of spatial components (d x K) 
-     OR 
+              matrix of spatial components (d x K)
+     OR
               A.T.dot(A) matrix (d x d) if flag_AA = true
-     flag_AA: boolean (default true)     
+     flag_AA: boolean (default true)
 
      Outputs:
      ---------
@@ -554,7 +557,7 @@ def update_order_greedy(A,flag_AA = True):
     for i in range(K):
         if i%100 == 0:
             print(i)
-            
+
         new_list = True
         for ls in O:
             #import pdb
@@ -569,14 +572,14 @@ def update_order_greedy(A,flag_AA = True):
                     ls.append(i)
                     new_list = False
                     break
-                
+
         if new_list:
             O.append([i])
-        
+
     lo = [len(ls) for ls in O]
     return O,lo
-        
-    
+
+
 
 #%%
 def order_components(A, C):


### PR DESCRIPTION
Sorry for all the diffs: my editor deletes trailing spaces so a lot of lines are changed. Real changes are:
- In cnmf.py, l.199: send alpha_snmf to CNMFParams
- In cnmf.py, l.210: this check is not necessary anymore
- In initialization.py, l. 96: check if alpha_snmf is None here
- In utilities, l. 88, put alpha_snmf in the options['initial_params']

Now, alpha_snmf gets managed like any of the other parameters, i.e., put in the dictionary and used whenever necessary.
Cheers,