### PR TITLE
Avoid IndexError in get_noise_fft

### DIFF
--- a/caiman/source_extraction/cnmf/pre_processing.py
+++ b/caiman/source_extraction/cnmf/pre_processing.py
@@ -151,13 +151,13 @@ def get_noise_fft(Y, noise_range = [0.25,0.5], noise_method = 'logmexp', max_num
         xdft = np.fft.rfft(Y,axis=-1)
         psdx = (old_div(1.,T))*abs(xdft)**2
         psdx[...,1:] *= 2
-        sn = mean_psd(psdx[...,ind], method = noise_method)
+        sn = mean_psd(psdx[...,ind[:psdx.shape[-1]]], method = noise_method)
 
     else:
         xdft = np.fliplr(np.fft.rfft(Y))
         psdx = (old_div(1.,T))*(xdft**2)
         psdx[1:] *=2
-        sn = mean_psd(psdx[ind], method = noise_method)
+        sn = mean_psd(psdx[ind[:psdx.shape[0]]], method = noise_method)
 
     return sn, psdx
 


### PR DESCRIPTION
The latest versions of numpy raise an IndexError rather than a warning when the shape of the indexing array does not match exactly the shape of the array itself.