### PR TITLE
Fixed error loading .tif files

### DIFF
--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -1922,9 +1922,17 @@ def tile_and_correct_wrapper(params):
     name, extension = os.path.splitext(img_name)[:2]
     
     if extension == '.tif' or extension == '.tiff':  # check if tiff file
-        imgs = imread(img_name,key = idxs)
-        mc = np.zeros(imgs.shape,dtype = np.float32)
-        shift_info = []
+        try:
+            imgs = imread(img_name,key = idxs)
+            mc = np.zeros(imgs.shape,dtype = np.float32)
+            shift_info = []
+        except IndexError as ie:
+            #if IndexError exception, then tiff movie is likely formatted as single-page
+            #so will just read as numpy array and get frames via indexing into the array
+            imgs_tmp = imread(img_name)
+            imgs = np.take(imgs_tmp, idxs, axis=0)
+            mc = np.zeros(imgs.shape,dtype = np.float32)
+            shift_info = []
     elif extension == '.sbx':  # check if sbx file
         imgs = cm.base.movies.sbxread(name, idxs[0], len(idxs))
         mc = np.zeros(imgs.shape,dtype = np.float32)


### PR DESCRIPTION
In motion_correction.py, the tiffile's imread() function uses a keyword argument `key` that indexes into the pages of a multi-page tif. Not all tif's are formatted as multi-page so this fails on perfectly valid tif files (e.g. those produced by saving from ImageJ). The workaround is to just use imread() without the `key` parameter which returns a Frames x Height x Width numpy array of the movie and then use np.take() function to select the frames as originally intended with the `key` parameter.