### PR TITLE
Bugs squashed

### DIFF
--- a/caiman/components_evaluation.py
+++ b/caiman/components_evaluation.py
@@ -491,7 +491,7 @@ def estimate_components_quality(traces, Y, A, C, b, f, final_frate = 30, Npeaks=
             fitness_raw = np.concatenate([fitness_raw,fitness_raw__])
             fitness_delta = np.concatenate([fitness_delta, fitness_delta__])
             r_values = np.concatenate([r_values ,r_values__])
-            significant_samples = np.concatenate([significant_samples,significant_samples__])
+            # significant_samples = np.concatenate([significant_samples,significant_samples__])
     
             if len(erfc_raw) == 0:
                 erfc_raw = erfc_raw__

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -1722,7 +1722,7 @@ def compute_metrics_motion_correction(fname,final_size_x,final_size_y, swap_dim,
     m = m[:,max_shft_x:max_shft_x_1,max_shft_y:max_shft_y_1]
     if np.sum(np.isnan(m))>0:
         print(m.shape)
-        raise Exception('Movie containts nan')
+        raise Exception('Movie contains nan')
         
     print('Local correlations..')
     img_corr = m.local_correlations(eight_neighbours=True, swap_dim = swap_dim)
@@ -1789,7 +1789,7 @@ def compute_metrics_motion_correction(fname,final_size_x,final_size_y, swap_dim,
 #%%
 def motion_correct_batch_rigid(fname, max_shifts, dview = None, splits = 56 ,num_splits_to_process = None, num_iter = 1,
                                 template = None, shifts_opencv = False, save_movie_rigid = False, add_to_movie = None,
-                               nonneg_movie = False, gSig_filt = None):
+                               nonneg_movie = False, gSig_filt = None, subidx=slice(None, None, 1)):
     """
     Function that perform memory efficient hyper parallelized rigid motion corrections while also saving a memory mappable file
 
@@ -1821,7 +1821,10 @@ def motion_correct_batch_rigid(fname, max_shifts, dview = None, splits = 56 ,num
 
     save_movie_rigid: boolean
          toggle save movie
-    
+
+    subidx: slice
+        Indices to slice
+
     Returns:
     --------    
     fname_tot_rig: str
@@ -1832,21 +1835,24 @@ def motion_correct_batch_rigid(fname, max_shifts, dview = None, splits = 56 ,num
         list of produced templates, one per batch
     
     shifts: list
-        inferred rigid shifts to corrrect the movie
+        inferred rigid shifts to correct the movie
 
     Raise:
     -----
         Exception('The movie contains nans. Nans are not allowed!')
     
     """
-    m = cm.load(fname,subindices=slice(0,None,10))
+    corrected_slicer = slice(subidx.start, subidx.stop, subidx.step*10)
+    m = cm.load(fname,subindices=corrected_slicer)
     
     if m.shape[0]<300:
-        m = cm.load(fname,subindices=slice(0,None,1))
+        m = cm.load(fname,subindices=corrected_slicer)
     elif m.shape[0]<500:
-        m = cm.load(fname,subindices=slice(0,None,5))
+        corrected_slicer = slice(subidx.start, subidx.stop, subidx.step*5)
+        m = cm.load(fname,subindices=corrected_slicer)
     else:
-        m = cm.load(fname,subindices=slice(0,None,30))
+        corrected_slicer = slice(subidx.start, subidx.stop, subidx.step*30)
+        m = cm.load(fname,subindices=corrected_slicer)
     
     if template is None:   
         if gSig_filt is not None:
@@ -2025,14 +2031,18 @@ def tile_and_correct_wrapper(params):
         1 #'Open CV is naturally single threaded'
 
     img_name,  out_fname,idxs, shape_mov, template, strides, overlaps, max_shifts,\
-        add_to_movie,max_deviation_rigid,upsample_factor_grid, newoverlaps, newstrides,shifts_opencv,nonneg_movie, gSig_filt  = params
+        add_to_movie,max_deviation_rigid,upsample_factor_grid, newoverlaps, newstrides, \
+        shifts_opencv,nonneg_movie, gSig_filt, is_fiji = params
 
     import os
 
     name, extension = os.path.splitext(img_name)[:2]
     
     if extension == '.tif' or extension == '.tiff':  # check if tiff file
-        imgs = imread(img_name,key = idxs)
+        if is_fiji:
+            imgs = imread(img_name)[idxs]
+        else:
+            imgs = imread(img_name, key=idxs)
         mc = np.zeros(imgs.shape,dtype = np.float32)
         shift_info = []
     elif extension == '.sbx':  # check if sbx file
@@ -2082,10 +2092,12 @@ def motion_correction_piecewise(fname, splits, strides, overlaps, add_to_movie=0
     import os
     import h5py
     name, extension = os.path.splitext(fname)[:2]
+    is_fiji = False
 
     if extension == '.tif' or extension == '.tiff':  # check if tiff file
         with tifffile.TiffFile(fname) as tf:
-           if len(tf) == 1:
+           if len(tf) == 1:  # Fiji-generated TIF
+               is_fiji = True
                T,d1,d2 = tf[0].shape
            else:    
                d1,d2 = tf[0].shape
@@ -2144,7 +2156,7 @@ def motion_correction_piecewise(fname, splits, strides, overlaps, add_to_movie=0
     for idx in idxs:
       pars.append([fname,fname_tot,idx,shape_mov, template, strides, overlaps, max_shifts, np.array(
           add_to_movie,dtype = np.float32),max_deviation_rigid,upsample_factor_grid,
-                   newoverlaps, newstrides, shifts_opencv,nonneg_movie, gSig_filt])
+                   newoverlaps, newstrides, shifts_opencv,nonneg_movie, gSig_filt, is_fiji])
     
     if dview is not None:
         print('** Startting parallel motion correction **')

--- a/demos_detailed/demo_pipeline.py
+++ b/demos_detailed/demo_pipeline.py
@@ -12,6 +12,8 @@
 
 from __future__ import division
 from __future__ import print_function
+import matplotlib
+matplotlib.use('TkAgg')
 from builtins import zip
 from builtins import str
 from builtins import map
@@ -53,6 +55,7 @@ from caiman.utils.visualization import plot_contours, view_patches_bar
 from caiman.source_extraction.cnmf import cnmf as cnmf
 from caiman.motion_correction import MotionCorrect
 from caiman.components_evaluation import estimate_components_quality
+from caiman.source_extraction.cnmf.utilities import extract_DF_F
 
 from caiman.components_evaluation import evaluate_components,evaluate_components_CNN
 
@@ -102,8 +105,10 @@ params_movie = {'fname': ['Sue_2x_3000_40_-46.tif'],
                'memory_fact': 1,
                'n_chunks': 10,
                'update_background_components': True,# whether to update the background components in the spatial phase
-               'low_rank_background': True  #whether to update the using a low rank approximation. In the False case all the nonzero elements of the background components are updated using hals    
-                                     #(to be used with one background per patch)                              
+               'low_rank_background': True,  #whether to update the using a low rank approximation. In the False case all the nonzero elements of the background components are updated using hals
+                                     #(to be used with one background per patch)
+                'num_of_channels': 1,
+                'channel_of_neurons': 1
                }
 
 #%%
@@ -520,9 +525,9 @@ print(' ***** ')
 print((len(traces)))
 print((len(idx_components)))
 # %% save results
+Cdf = extract_DF_F(Yr=Yr, A=A, C=C, bl=cnm.bl)
 np.savez(os.path.join(os.path.split(fname_new)[0], os.path.split(fname_new)[1][:-4] + 'results_analysis.npz'), Cn=Cn,
-         A=A,
-         C=C, b=b, f=f, YrA=YrA, sn=sn, d1=d1, d2=d2, idx_components=idx_components,
+         A=A, Cdf = Cdf, C=C, b=b, f=f, YrA=YrA, sn=sn, d1=d1, d2=d2, idx_components=idx_components,
          idx_components_bad=idx_components_bad,
          fitness_raw=fitness_raw, fitness_delta=fitness_delta, r_values=r_values)
 # we save it


### PR DESCRIPTION
1. In the main pipeline I've added a call to the DF/F calculation function.
2. I started doing preparations for slice-based readout of files. This is important for cases in which a stack is interleaved with more than one spectral channel. The online pipeline already has support for this, I'm trying to bring this one on par. It's still not ready, though.
3. I commented out a line in `components_evaluation.py` which causes bugs (the first change below). It seems like no one is using this `significant_samples` variables, so I allowed myself to do it. It was hard to reproduce, so I can't tell exactly what caused the issue, but generally, the error was caused by the fact that sometimes `signifcant_samples__` contained a heterogeneous list of arrays and numbers, which meant that `np.concatenate` couldn't simply coerce it into an array. The problem was that this didn't happen with every stack - and I couldn't find the pattern connecting the stacks that were affected. 
4. When saving a stack with Fiji the `key` keyword in `tifffile.imread` is pretty useless, since there's only one key. Instead, if you want to read only a substack of the full file - you have to first load it into memory and then slice it. I couldn't find a better way which supports both Python versions, and it's only a problem if the stack was generated by ImageJ anyways.
5. All tests seem to pass.

Also, I would really like if `demo_pipeline.py` was a function instead of a script, with its inputs being these large `params` dicts. Right now it's not trivial to call it from wrapper scripts and to post-process its output. I will obviously send the pull request if you deem this change useful.