### PR TITLE
Fix potential error in timeseries.py

### DIFF
--- a/caiman/base/timeseries.py
+++ b/caiman/base/timeseries.py
@@ -183,7 +183,11 @@ class timeseries(np.ndarray):
 
 
         elif extension == '.avi':
-            codec=cv2.cv.FOURCC('I','Y','U','V')
+            codec = None
+            try:
+                codec=cv2.FOURCC('I','Y','U','V')
+            except AttributeError:
+                codec = cv2.VideoWriter_fourcc(*'IYUV')
             np.clip(self,np.percentile(self,1),np.percentile(self,99),self)
             minn,maxx = np.min(self),np.max(self)
             data = 255 * (self-minn)/(maxx-minn)


### PR DESCRIPTION
The opencv cv2 module no longer contains a cv2.cv module, so I was getting an error trying to save a movie object as an AVI file. I propose a simple try/except block to handle both the old API and the new version. Works for me.