### PR TITLE
Fix potential error in visualization.py

### DIFF
--- a/caiman/utils/visualization.py
+++ b/caiman/utils/visualization.py
@@ -157,7 +157,7 @@ def nb_view_patches(Yr, A, C, b, f, d1, d2, YrA = None, image_neurons=None, thr=
     colormap = cm.get_cmap(cmap)
     grayp = [mpl.colors.rgb2hex(m) for m in colormap(np.arange(colormap.N))]
     nr, T = C.shape
-    nA2 = np.ravel(A.power(2).sum(0))
+    nA2 = np.ravel(np.power(A,2).sum(0)) if type(A) == np.ndarray else np.ravel(A.power(2).sum(0))
     b = np.squeeze(b)
     f = np.squeeze(f)
     if YrA is None:


### PR DESCRIPTION
Line 160 tries to call the power method on a `ndarray A.power(2)` however I got the error `AttributeError: 'numpy.ndarray' object has no attribute 'power'` and indeed the numpy docs: < https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.power.html > do not suggest that `ndarray` objects have a power method. You have to do `np.power(A,2)`. In my hands, if I run without patches mode, then the `A` matrix is a normal `ndarray` not a `coo_matrix` thus the line throws an exception. This PR will allow it to handle either case.