### PR TITLE
Fix some windows-specific calls

### DIFF
--- a/caiman/components_evaluation.py
+++ b/caiman/components_evaluation.py
@@ -496,7 +496,7 @@ def estimate_components_quality(traces, Y, A, C, b, f, final_frate = 30, Npeaks=
             
             print('EVALUATING IN PARALLEL... NOT RETURNING ERFCs')
             if 'multiprocessing' in str(type(dview)):
-                res = dview.map_async(evaluate_components_placeholder,params).get(9999999)
+                res = dview.map_async(evaluate_components_placeholder,params).get(4294967)
             else:
                 res = dview.map_sync(evaluate_components_placeholder,params)
         

--- a/caiman/mmapping.py
+++ b/caiman/mmapping.py
@@ -130,7 +130,7 @@ def save_memmap_each(fnames, dview=None, base_name=None, resize_fact=(1, 1, 1), 
 
     if dview is not None:
         if 'multiprocessing' in str(type(dview)):
-            fnames_new = dview.map_async(save_place_holder, pars).get(9999999)
+            fnames_new = dview.map_async(save_place_holder, pars).get(4294967)
         else:
             fnames_new = dview.map_sync(save_place_holder, pars)
     else:
@@ -195,7 +195,7 @@ def save_memmap_join(mmap_fnames, base_name=None, n_chunks=20, dview=None, async
 
     if dview is not None:
         if 'multiprocessing' in str(type(dview)):
-            dview.map_async(save_portion, pars).get(9999999)            
+            dview.map_async(save_portion, pars).get(4294967)
         else:
             dview.map_sync(save_portion, pars)
     else:
@@ -351,6 +351,11 @@ def save_memmap(filenames, base_name='Yr', resize_fact=(1, 1, 1), remove_init=0,
         Ttot = Ttot + T
 
     fname_new = fname_tot + '_frames_' + str(Ttot) + '_.mmap'
+    try:
+        # need to explicitly remove destination on windows
+        os.unlink(fname_new)
+    except OSError:
+        pass
     os.rename(fname_tot, fname_new)
 
     return fname_new
@@ -517,7 +522,7 @@ def parallel_dot_product(A, b, block_size=5000, dview=None, transpose=False, num
         for itera in range(0, len(pars), num_blocks_per_run):
             
             if 'multiprocessing' in str(type(dview)):
-                results = dview.map_async(dot_place_holder, pars[itera:itera + num_blocks_per_run]).get(9999999)
+                results = dview.map_async(dot_place_holder, pars[itera:itera + num_blocks_per_run]).get(4294967)
             else:
                 results = dview.map_sync(dot_place_holder, pars[itera:itera + num_blocks_per_run])
                 

--- a/caiman/motion_correction.py
+++ b/caiman/motion_correction.py
@@ -976,7 +976,7 @@ def motion_correct_parallel(file_names,fr=10,template=None,margins_out=0,
     try:
         if dview is not None:
             if 'multiprocessing' in str(type(dview)):
-                file_res = dview.map_async(process_movie_parallel, args_in).get(9999999)
+                file_res = dview.map_async(process_movie_parallel, args_in).get(4294967)
             else:
                 file_res = dview.map_sync(process_movie_parallel, args_in)                         
                 dview.results.clear()
@@ -2208,7 +2208,7 @@ def motion_correction_piecewise(fname, splits, strides, overlaps, add_to_movie=0
     if dview is not None:
         print('** Startting parallel motion correction **')
         if 'multiprocessing' in str(type(dview)):
-            res = dview.map_async(tile_and_correct_wrapper,pars).get(9999999)
+            res = dview.map_async(tile_and_correct_wrapper,pars).get(4294967)
         else:
             res = dview.map_sync(tile_and_correct_wrapper,pars)
         print('** Finished parallel motion correction **')

--- a/caiman/source_extraction/cnmf/map_reduce.py
+++ b/caiman/source_extraction/cnmf/map_reduce.py
@@ -249,7 +249,7 @@ def run_CNMF_patches(file_name, shape, options, rf=16, stride=4, gnb=1, dview=No
     st = time.time()
     if dview is not None:
         if 'multiprocessing' in str(type(dview)):
-            file_res = dview.map_async(cnmf_patches, args_in).get(9999999)
+            file_res = dview.map_async(cnmf_patches, args_in).get(4294967)
         else:
             try:
                 file_res = dview.map_sync(cnmf_patches, args_in)

--- a/caiman/source_extraction/cnmf/pre_processing.py
+++ b/caiman/source_extraction/cnmf/pre_processing.py
@@ -225,7 +225,7 @@ def get_noise_fft_parallel(Y,n_pixels_per_process=100, dview=None, **kwargs):
     
     else:        
         if 'multiprocessing' in str(type(dview)):
-            results = dview.map_async(fft_psd_multithreading, argsin).get(9999999)
+            results = dview.map_async(fft_psd_multithreading, argsin).get(4294967)
         else:
             ne = len(dview)
             print(('Running on %d engines.'%(ne)))

--- a/caiman/source_extraction/cnmf/spatial.py
+++ b/caiman/source_extraction/cnmf/spatial.py
@@ -206,7 +206,7 @@ def update_spatial_components(Y, C=None, f=None, A_in=None, sn=None, dims=None, 
     A_ = np.zeros((d, nr + np.size(f, 0)))    #init A_
     if dview is not None:
         if 'multiprocessing' in str(type(dview)):
-            parallel_result = dview.map_async(regression_ipyparallel, pixel_groups).get(9999999)
+            parallel_result = dview.map_async(regression_ipyparallel, pixel_groups).get(4294967)
         else:
             parallel_result = dview.map_sync(regression_ipyparallel, pixel_groups)
             dview.results.clear()
@@ -494,7 +494,7 @@ def determine_search_location(A, dims, method='ellipse', min_size=3, max_size=8,
                 res = list(map(construct_ellipse_parallel, pars))
             else:
                 if 'multiprocessing' in str(type(dview)):
-                    res = dview.map_async(construct_ellipse_parallel, pars).get(9999999)
+                    res = dview.map_async(construct_ellipse_parallel, pars).get(4294967)
                 else:
                     res = dview.map_sync(construct_ellipse_parallel, pars)
             for r in res:
@@ -648,7 +648,7 @@ def threshold_components(A, dims, medw=None, thr_method='nrg', maxthr=0.1, nrgth
 
     if dview is not None:
         if 'multiprocessing' in str(type(dview)):
-            res = dview.map_async(threshold_components_parallel, pars).get(9999999)
+            res = dview.map_async(threshold_components_parallel, pars).get(4294967)
         else:
             res = dview.map_async(threshold_components_parallel, pars)
     else:

--- a/caiman/source_extraction/cnmf/temporal.py
+++ b/caiman/source_extraction/cnmf/temporal.py
@@ -367,7 +367,7 @@ def update_iteration (parrllcomp, len_parrllcomp, nb,C, S, bl, nr,
                         None, None, None, kwargs) for jj in range(len(jo))]
             #computing the most likely discretized spike train underlying a fluorescence trace
             if 'multiprocessing' in str(type(dview)):                
-                results = dview.map_async(constrained_foopsi_parallel, args_in).get(9999999)                    
+                results = dview.map_async(constrained_foopsi_parallel, args_in).get(4294967)
             
             elif dview is not None and platform.system()!='Darwin':                                    
                 if debug:


### PR DESCRIPTION
Addresses some errors when running on windows.  Should have no significant effect on behavior.

`os.rename` will not delete an existing destination file, so delete it first.

`threading.Condition.wait` has a maximum timeout of 2^32 ms.  (However, it may be better and more efficient to use a timeout of `None` in these cases -- finite timeouts involve polling so will be slower.)

`fmax` is not defined for the old VC9 compiler python2 uses (python3 is fine), but the standard python `max` (which just expands to an inline ternary) looks like it should be fine in most cases.